### PR TITLE
handle ::shorthand/keywords

### DIFF
--- a/src/cljsee/parse.clj
+++ b/src/cljsee/parse.clj
@@ -31,11 +31,16 @@
   (let [form (#'rdr/read* rdr true nil opts pending-forms)]
     (->ReadEval form)))
 
-(defn disabled-read-keyword
-  "Read ::foo/keywords without context"
+(defn special-read-keyword
+  "Read ::alias/keywords without namespace context"
   [rdr _ opts pending-forms]
-  (let [form (#'rdr/read* rdr true nil opts pending-forms)]
-    (keyword (str form))))
+  (assert (empty? pending-forms))
+  (let [tok (#'rdr/read-token rdr \:)
+        sl (str/index-of tok \/)]
+    (keyword (when sl (subs tok 1 sl))
+             (if sl
+               (subs tok (inc sl))
+               (subs tok 1)))))
 
 (defrecord ReadCond [splicing form lc-metas]) ; stores a form (:clj 1 :cljs 2 ...) and a list of
                                               ; line-column metadata for each element within.
@@ -88,7 +93,7 @@
 (defn modified-read-string
   [s]
   (with-redefs [rdr/read-eval disabled-read-eval
-                rdr/read-keyword disabled-read-keyword
+                rdr/read-keyword special-read-keyword
                 rdr/read-cond special-read-cond]
     (let [rdr (t/indexing-push-back-reader s)]
       (->> #(rdr/read {:read-cond :preserve :eof ::eof} rdr)

--- a/src/cljsee/parse.clj
+++ b/src/cljsee/parse.clj
@@ -31,6 +31,12 @@
   (let [form (#'rdr/read* rdr true nil opts pending-forms)]
     (->ReadEval form)))
 
+(defn disabled-read-keyword
+  "Read ::foo/keywords without context"
+  [rdr _ opts pending-forms]
+  (let [form (#'rdr/read* rdr true nil opts pending-forms)]
+    (keyword (str form))))
+
 (defrecord ReadCond [splicing form lc-metas]) ; stores a form (:clj 1 :cljs 2 ...) and a list of
                                               ; line-column metadata for each element within.
 
@@ -82,6 +88,7 @@
 (defn modified-read-string
   [s]
   (with-redefs [rdr/read-eval disabled-read-eval
+                rdr/read-keyword disabled-read-keyword
                 rdr/read-cond special-read-cond]
     (let [rdr (t/indexing-push-back-reader s)]
       (->> #(rdr/read {:read-cond :preserve :eof ::eof} rdr)

--- a/test/cljsee/core_test.clj
+++ b/test/cljsee/core_test.clj
@@ -65,7 +65,18 @@
 
     ;; same if we switch it around
     "#=(/ #?@(:a [1 0]))" #{:a}
-    "#=(/         1 0  )")
+    "#=(/         1 0  )"
+
+    ;; test keywords
+    "#?(:a :simple-keyword)" #{:a} "      :simple-keyword "
+    "#?(:a :namespaced/keyword)" #{:a} "      :namespaced/keyword "
+    "#?(:a ::alias/keyword)" #{:a} "      ::alias/keyword "
+    "#?(:a :simple-keyword)" #{:B} "                      "
+    "#?(:a :namespaced/keyword)" #{:B} "                          "
+    "#?(:a ::alias/keyword)" #{:B} "                      "
+    ":simple-keyword" #{:a} ":simple-keyword"
+    ":namespaced/keyword" #{:a} ":namespaced/keyword"
+    "::alias/keyword" #{:a} "::alias/keyword")
 
   ;; ensure comments don't prevent the readcond from parsing, but we
   ;; don't guarantee whether they end up in the result of the parse.

--- a/test/cljsee/core_test.clj
+++ b/test/cljsee/core_test.clj
@@ -76,7 +76,10 @@
     "#?(:a ::alias/keyword)" #{:B} "                      "
     ":simple-keyword" #{:a} ":simple-keyword"
     ":namespaced/keyword" #{:a} ":namespaced/keyword"
-    "::alias/keyword" #{:a} "::alias/keyword")
+    "::alias/keyword" #{:a} "::alias/keyword"
+    ":2pac" {} ":2pac"
+    ":2p/ac" {} ":2p/ac"
+    "::2p/ac" {} "::2p/ac")
 
   ;; ensure comments don't prevent the readcond from parsing, but we
   ;; don't guarantee whether they end up in the result of the parse.


### PR DESCRIPTION
right now, cljsee throws when encountering `::alias/keywords`. This patch fixes it.